### PR TITLE
Add Firo support to address codec and Rosen extractor

### DIFF
--- a/.changeset/early-lemons-rest.md
+++ b/.changeset/early-lemons-rest.md
@@ -1,0 +1,5 @@
+---
+'@rosen-bridge/address-codec': minor
+---
+
+Add support for Firo chain

--- a/.changeset/hip-coins-give.md
+++ b/.changeset/hip-coins-give.md
@@ -1,0 +1,5 @@
+---
+'@rosen-bridge/rosen-extractor': minor
+---
+
+Add Firo chain support with FiroRosenExtractor and FiroRpcRosenExtractor

--- a/packages/address-codec/lib/const.ts
+++ b/packages/address-codec/lib/const.ts
@@ -5,6 +5,7 @@ export const ERGO_CHAIN = 'ergo';
 export const ETHEREUM_CHAIN = 'ethereum';
 export const BINANCE_CHAIN = 'binance';
 export const DOGE_CHAIN = 'doge';
+export const FIRO_CHAIN = 'firo';
 
 export const DOGE_NETWORK = {
   // Doge network parameters
@@ -17,4 +18,17 @@ export const DOGE_NETWORK = {
   pubKeyHash: 0x1e,
   scriptHash: 0x16,
   wif: 0x9e,
+};
+
+export const FIRO_NETWORK = {
+  // Firo network parameters
+  messagePrefix: '\x19Firo Signed Message:\n',
+  bech32: 'firo',
+  bip32: {
+    public: 0x0488b21e,
+    private: 0x0488ade4,
+  },
+  pubKeyHash: 0x52,
+  scriptHash: 0x07,
+  wif: 0xd2,
 };

--- a/packages/address-codec/lib/decoder.ts
+++ b/packages/address-codec/lib/decoder.ts
@@ -7,6 +7,8 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
+  FIRO_NETWORK,
 } from './const';
 import { UnsupportedAddressError, UnsupportedChainError } from './types';
 import * as ergoLib from 'ergo-lib-wasm-nodejs';
@@ -50,6 +52,11 @@ export const decodeAddress = (
       return bitcoinLib.address.fromOutputScript(
         Buffer.from(encodedAddress, 'hex'),
         DOGE_NETWORK,
+      );
+    case FIRO_CHAIN:
+      return bitcoinLib.address.fromOutputScript(
+        Buffer.from(encodedAddress, 'hex'),
+        FIRO_NETWORK,
       );
     default:
       throw new UnsupportedChainError(chain);

--- a/packages/address-codec/lib/encoder.ts
+++ b/packages/address-codec/lib/encoder.ts
@@ -7,6 +7,8 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
+  FIRO_NETWORK,
 } from './const';
 import { UnsupportedAddressError, UnsupportedChainError } from './types';
 import * as ergoLib from 'ergo-lib-wasm-nodejs';
@@ -46,6 +48,11 @@ export const encodeAddress = (chain: string, address: string): string => {
     case DOGE_CHAIN:
       encoded = bitcoinLib.address
         .toOutputScript(address, DOGE_NETWORK)
+        .toString('hex');
+      break;
+    case FIRO_CHAIN:
+      encoded = bitcoinLib.address
+        .toOutputScript(address, FIRO_NETWORK)
         .toString('hex');
       break;
     default:

--- a/packages/address-codec/lib/validator.ts
+++ b/packages/address-codec/lib/validator.ts
@@ -7,6 +7,8 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
+  FIRO_NETWORK,
 } from './const';
 import { UnsupportedAddressError, UnsupportedChainError } from './types';
 import * as ergoLib from 'ergo-lib-wasm-nodejs';
@@ -49,6 +51,13 @@ export const validateAddress = (chain: string, address: string): boolean => {
         bitcoinLib.address.toOutputScript(address);
         if (address.slice(0, 4) != 'bc1p')
           throw new UnsupportedAddressError(chain, address);
+      } catch {
+        throw new UnsupportedAddressError(chain, address);
+      }
+      return true;
+    case FIRO_CHAIN:
+      try {
+        bitcoinLib.address.toOutputScript(address, FIRO_NETWORK);
       } catch {
         throw new UnsupportedAddressError(chain, address);
       }

--- a/packages/address-codec/tests/decoder.spec.ts
+++ b/packages/address-codec/tests/decoder.spec.ts
@@ -11,6 +11,7 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
 } from '../lib/const';
 
 describe('decodeAddress', () => {
@@ -127,5 +128,19 @@ describe('decodeAddress', () => {
       testData.encodedTaprootBitcoinAddress,
     );
     expect(res).toEqual(testData.taprootBitcoinAddress);
+  });
+
+  /**
+   * @target `decodeAddress` should decode Firo address successfully
+   * @dependencies
+   * @scenario
+   * - run test
+   * - check returned value
+   * @expected
+   * - it should be address in hex format
+   */
+  it('should decode Firo address successfully', () => {
+    const res = decodeAddress(FIRO_CHAIN, testData.encodedFiroAddress);
+    expect(res).toEqual(testData.firoAddress);
   });
 });

--- a/packages/address-codec/tests/encoder.spec.ts
+++ b/packages/address-codec/tests/encoder.spec.ts
@@ -11,6 +11,7 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
 } from '../lib/const';
 
 describe('encodeAddress', () => {
@@ -139,5 +140,19 @@ describe('encodeAddress', () => {
   it('should encode Runes address successfully', () => {
     const res = encodeAddress(RUNES_CHAIN, testData.taprootBitcoinAddress);
     expect(res).toEqual(testData.encodedTaprootBitcoinAddress);
+  });
+
+  /**
+   * @target `encodeAddress` should encode Firo address successfully
+   * @dependencies
+   * @scenario
+   * - run test
+   * - check returned value
+   * @expected
+   * - it should be output script of given address in hex
+   */
+  it('should encode Firo address successfully', () => {
+    const res = encodeAddress(FIRO_CHAIN, testData.firoAddress);
+    expect(res).toEqual(testData.encodedFiroAddress);
   });
 });

--- a/packages/address-codec/tests/testData.ts
+++ b/packages/address-codec/tests/testData.ts
@@ -41,3 +41,8 @@ export const dogeAddress = 'A69cznKpaYVWjzU3sNFZnGhbpSmUVFzvHB';
 export const invalidDogeAddress = 'bc1qkgp89fjerymm5ltg0hygnumr0m2qa7n22gyw6h';
 export const encodedDogeAddress =
   'a914966ba9f4755996c3d51025d53044b415121bc10287';
+
+export const firoAddress = 'a41owUrDFUy7taaQjntHqUadXm49d4z65e';
+export const invalidFiroAddress = 'bc1qkgp89fjerymm5ltg0hygnumr0m2qa7n22gyw6h';
+export const encodedFiroAddress =
+  '76a91424304f7ac11d0bcb0de1ebc6e2ea6aae174aee8988ac';

--- a/packages/address-codec/tests/validator.spec.ts
+++ b/packages/address-codec/tests/validator.spec.ts
@@ -11,6 +11,7 @@ import {
   ERGO_CHAIN,
   ETHEREUM_CHAIN,
   RUNES_CHAIN,
+  FIRO_CHAIN,
 } from '../lib/const';
 
 describe('validateAddress', () => {
@@ -229,6 +230,33 @@ describe('validateAddress', () => {
   it('should throw error for wrong Runes address', () => {
     expect(() => {
       validateAddress(RUNES_CHAIN, testData.bitcoinAddress);
+    }).toThrow(UnsupportedAddressError);
+  });
+
+  /**
+   * @target `validateAddress` should validate Firo address successfully
+   * @dependencies
+   * @scenario
+   * - run test
+   * @expected
+   * - to validate correct Firo address
+   */
+  it('should validate Firo address successfully', () => {
+    const res = validateAddress(FIRO_CHAIN, testData.firoAddress);
+    expect(res).toEqual(true);
+  });
+
+  /**
+   * @target `validateAddress` should throw error for wrong Firo address
+   * @dependencies
+   * @scenario
+   * - run test
+   * @expected
+   * - to throw error for wrong Firo address
+   */
+  it('should throw error for wrong Firo address', () => {
+    expect(() => {
+      validateAddress(FIRO_CHAIN, testData.invalidFiroAddress);
     }).toThrow(UnsupportedAddressError);
   });
 });

--- a/packages/rosen-extractor/lib/getRosenData/const.ts
+++ b/packages/rosen-extractor/lib/getRosenData/const.ts
@@ -9,6 +9,8 @@ export const ERGO_CHAIN = 'ergo';
 export const DOGE_CHAIN = 'doge';
 export const DOGE_NATIVE_TOKEN = 'doge';
 export const BITCOIN_RUNES_CHAIN = 'bitcoin-runes';
+export const FIRO_CHAIN = 'firo';
+export const FIRO_NATIVE_TOKEN = 'firo';
 export const SUPPORTED_CHAINS = [
   ERGO_CHAIN,
   CARDANO_CHAIN,
@@ -17,4 +19,5 @@ export const SUPPORTED_CHAINS = [
   BINANCE_CHAIN,
   DOGE_CHAIN,
   BITCOIN_RUNES_CHAIN,
+  FIRO_CHAIN,
 ];

--- a/packages/rosen-extractor/lib/getRosenData/firo/firoRosenExtractor.ts
+++ b/packages/rosen-extractor/lib/getRosenData/firo/firoRosenExtractor.ts
@@ -1,0 +1,143 @@
+import { RosenData, TokenTransformation } from '../abstract/types';
+import AbstractRosenDataExtractor from '../abstract/abstractRosenDataExtractor';
+import { FIRO_CHAIN, FIRO_NATIVE_TOKEN } from '../const';
+import { FiroTx, FiroTxOutput } from './types';
+import { MinimalOnChainRosenData } from '../../types';
+import { TokenMap } from '@rosen-bridge/tokens';
+import { AbstractLogger } from '@rosen-bridge/abstract-logger';
+import { parseOpReturn, addressToOutputScript } from './utils';
+import JsonBigInt from '@rosen-bridge/json-bigint';
+
+export class FiroRosenExtractor extends AbstractRosenDataExtractor<string> {
+  readonly chain = FIRO_CHAIN;
+  protected lockScriptPubKey: string;
+
+  constructor(
+    lockAddress: string,
+    tokens: TokenMap,
+    logger?: AbstractLogger,
+    storeRawData = true,
+  ) {
+    super(lockAddress, tokens, logger, storeRawData);
+    this.lockScriptPubKey = addressToOutputScript(lockAddress);
+  }
+
+  /**
+   * extracts RosenData from given lock transaction in FiroTx format
+   * @param serializedTransaction stringified transaction in FiroTx format
+   */
+  extractData = (serializedTransaction: string): RosenData | undefined => {
+    let transaction: FiroTx;
+    try {
+      transaction = JsonBigInt.parse(serializedTransaction);
+    } catch (e) {
+      throw new Error(
+        `Failed to parse transaction json to FiroTx format while extracting rosen data: ${e}`,
+      );
+    }
+    const baseError = `No rosen data found for tx [${transaction.id}]`;
+    try {
+      const outputs = transaction.outputs;
+      if (outputs.length < 2) {
+        this.logger.debug(baseError + `: Insufficient number of boxes`);
+        return undefined;
+      }
+
+      let validData = false; // an OP_RETURN box with valid data is found
+      let validLock = false; // a lock box is found with available asset transformation
+
+      // parse rosen data from OP_RETURN box
+      let opReturnData: MinimalOnChainRosenData | undefined;
+      let rawData: string = '';
+      for (let i = 0; i < outputs.length; i++) {
+        const output = outputs[i];
+        if (output.scriptPubKey.slice(0, 2) !== '6a') continue; // not an OP_RETURN utxo
+
+        try {
+          opReturnData = parseOpReturn(output.scriptPubKey);
+          rawData = output.scriptPubKey;
+          validData = true;
+          break;
+        } catch (e) {
+          this.logger.debug(
+            `Failed to extract data from OP_RETURN box [${transaction.id}.${i}]: ${e}`,
+          );
+        }
+      }
+      if (!validData || !opReturnData) {
+        this.logger.debug(
+          baseError + `: No OP_RETURN box with valid data is found`,
+        );
+        return undefined;
+      }
+
+      // find target chain token id
+      let assetTransformation: TokenTransformation | undefined;
+      for (let i = 0; i < outputs.length; i++) {
+        const output = outputs[i];
+        if (output.scriptPubKey !== this.lockScriptPubKey) continue; // utxo address is not lock address
+        assetTransformation = this.getAssetTransformation(
+          output,
+          opReturnData.toChain,
+        );
+        if (assetTransformation) {
+          validLock = true;
+          break;
+        }
+      }
+      if (!validLock || !assetTransformation) {
+        this.logger.debug(
+          baseError + `: Failed to find rosen asset transformation`,
+        );
+        return undefined;
+      }
+
+      const fromAddress = `box:${transaction.inputs[0].txId}.${transaction.inputs[0].index}`;
+      return {
+        toChain: opReturnData.toChain,
+        toAddress: opReturnData.toAddress,
+        bridgeFee: opReturnData.bridgeFee,
+        networkFee: opReturnData.networkFee,
+        fromAddress: fromAddress,
+        sourceChainTokenId: assetTransformation.from,
+        amount: assetTransformation.amount,
+        targetChainTokenId: assetTransformation.to,
+        sourceTxId: transaction.id,
+        rawData,
+      };
+    } catch (e) {
+      this.logger.debug(
+        `An error occurred while getting Firo rosen data: ${e}`,
+      );
+      if (e instanceof Error && e.stack) {
+        this.logger.debug(e.stack);
+      }
+    }
+    return undefined;
+  };
+
+  /**
+   * extracts and builds token transformation from UTXO and tokenMap
+   * @param box transaction output
+   * @param toChain event target chain
+   */
+  getAssetTransformation = (
+    box: FiroTxOutput,
+    toChain: string,
+  ): TokenTransformation | undefined => {
+    // try to build transformation using locked FIRO
+    const wrappedFiro = this.tokens.search(FIRO_CHAIN, {
+      tokenId: FIRO_NATIVE_TOKEN,
+    });
+    if (wrappedFiro.length > 0 && Object.hasOwn(wrappedFiro[0], toChain)) {
+      const value = box.value.toString();
+      return {
+        from: FIRO_NATIVE_TOKEN,
+        to: this.tokens.getID(wrappedFiro[0], toChain),
+        amount: value,
+      };
+    } else {
+      return undefined;
+    }
+  };
+}

--- a/packages/rosen-extractor/lib/getRosenData/firo/firoRpcRosenExtractor.ts
+++ b/packages/rosen-extractor/lib/getRosenData/firo/firoRpcRosenExtractor.ts
@@ -1,0 +1,135 @@
+import { RosenData, TokenTransformation } from '../abstract/types';
+import AbstractRosenDataExtractor from '../abstract/abstractRosenDataExtractor';
+import { FIRO_CHAIN, FIRO_NATIVE_TOKEN } from '../const';
+import { FiroRpcTransaction, FiroRpcTxOutput } from './types';
+import { MinimalOnChainRosenData } from '../../types';
+import { TokenMap } from '@rosen-bridge/tokens';
+import { AbstractLogger } from '@rosen-bridge/abstract-logger';
+import { parseOpReturn, addressToOutputScript } from './utils';
+
+export class FiroRpcRosenExtractor extends AbstractRosenDataExtractor<FiroRpcTransaction> {
+  readonly chain = FIRO_CHAIN;
+  protected lockScriptPubKey: string;
+
+  constructor(
+    lockAddress: string,
+    tokens: TokenMap,
+    logger?: AbstractLogger,
+    storeRawData = true,
+  ) {
+    super(lockAddress, tokens, logger, storeRawData);
+    this.lockScriptPubKey = addressToOutputScript(lockAddress);
+  }
+
+  /**
+   * extracts RosenData from given lock transaction in Rpc format
+   * @param transaction the lock transaction in Rpc format
+   */
+  extractData = (transaction: FiroRpcTransaction): RosenData | undefined => {
+    const baseError = `No rosen data found for tx [${transaction.txid}]`;
+    try {
+      const outputs = transaction.vout;
+      if (outputs.length < 2) {
+        this.logger.debug(baseError + `: Insufficient number of boxes`);
+        return undefined;
+      }
+
+      let validData = false; // an OP_RETURN box with valid data is found
+      let validLock = false; // a lock box is found with available asset transformation
+
+      // parse rosen data from OP_RETURN box
+      let opReturnData: MinimalOnChainRosenData | undefined;
+      let rawData: string = '';
+      for (let i = 0; i < outputs.length; i++) {
+        const output = outputs[i];
+        if (output.scriptPubKey.hex.slice(0, 2) !== '6a') continue; // not an OP_RETURN utxo
+
+        try {
+          opReturnData = parseOpReturn(output.scriptPubKey.hex);
+          rawData = output.scriptPubKey.hex;
+          validData = true;
+          break;
+        } catch (e) {
+          this.logger.debug(
+            `Failed to extract data from OP_RETURN box [${transaction.txid}.${i}]: ${e}`,
+          );
+        }
+      }
+      if (!validData || !opReturnData) {
+        this.logger.debug(
+          baseError + `: No OP_RETURN box with valid data is found`,
+        );
+        return undefined;
+      }
+
+      // find target chain token id
+      let assetTransformation: TokenTransformation | undefined;
+      for (let i = 0; i < outputs.length; i++) {
+        const output = outputs[i];
+        if (output.scriptPubKey.hex !== this.lockScriptPubKey) continue; // utxo address is not lock address
+        assetTransformation = this.getAssetTransformation(
+          output,
+          opReturnData.toChain,
+        );
+        if (assetTransformation) {
+          validLock = true;
+          break;
+        }
+      }
+      if (!validLock || !assetTransformation) {
+        this.logger.debug(
+          baseError + `: Failed to find rosen asset transformation`,
+        );
+        return undefined;
+      }
+
+      const fromAddress = `box:${transaction.vin[0].txid}.${transaction.vin[0].vout}`;
+      return {
+        toChain: opReturnData.toChain,
+        toAddress: opReturnData.toAddress,
+        bridgeFee: opReturnData.bridgeFee,
+        networkFee: opReturnData.networkFee,
+        fromAddress: fromAddress,
+        sourceChainTokenId: assetTransformation.from,
+        amount: assetTransformation.amount,
+        targetChainTokenId: assetTransformation.to,
+        sourceTxId: transaction.txid,
+        rawData,
+      };
+    } catch (e) {
+      this.logger.debug(
+        `An error occurred while getting Firo rosen data from Rpc: ${e}`,
+      );
+      if (e instanceof Error && e.stack) {
+        this.logger.debug(e.stack);
+      }
+    }
+    return undefined;
+  };
+
+  /**
+   * extracts and builds token transformation from UTXO and tokenMap
+   * @param box transaction output
+   * @param toChain event target chain
+   */
+  getAssetTransformation = (
+    box: FiroRpcTxOutput,
+    toChain: string,
+  ): TokenTransformation | undefined => {
+    // try to build transformation using locked FIRO
+    const wrappedFiro = this.tokens.search(FIRO_CHAIN, {
+      tokenId: FIRO_NATIVE_TOKEN,
+    });
+    if (wrappedFiro.length > 0 && Object.hasOwn(wrappedFiro[0], toChain)) {
+      const parts = box.value.toString().split('.');
+      const part1 = ((parts[1] ?? '') + '0'.repeat(8)).substring(0, 8);
+      return {
+        from: FIRO_NATIVE_TOKEN,
+        to: this.tokens.getID(wrappedFiro[0], toChain),
+        amount: (parts[0] === '0' ? '' : parts[0]) + part1,
+      };
+    } else {
+      return undefined;
+    }
+  };
+}

--- a/packages/rosen-extractor/lib/getRosenData/firo/types.ts
+++ b/packages/rosen-extractor/lib/getRosenData/firo/types.ts
@@ -1,0 +1,60 @@
+export interface FiroTxInput {
+  txId: string;
+  index: number;
+  scriptPubKey: string;
+}
+
+export interface FiroTxOutput {
+  scriptPubKey: string;
+  value: bigint;
+}
+
+export interface FiroTx {
+  id: string;
+  inputs: FiroTxInput[];
+  outputs: FiroTxOutput[];
+}
+
+// Transaction input types (in Firo getrawtransaction RPC response)
+export interface FiroRpcTxInput {
+  txid: string;
+  vout: number;
+  scriptSig: {
+    asm: string;
+    hex: string;
+  };
+  sequence: number;
+  txinwitness?: string[];
+}
+
+// Transaction output types (in Firo getrawtransaction RPC response)
+export interface FiroRpcTxOutput {
+  value: number;
+  n: number;
+  scriptPubKey: {
+    asm: string;
+    hex: string;
+    reqSigs?: number;
+    type: string;
+    addresses?: string[];
+  };
+}
+
+// Firo getrawtransaction RPC response
+export interface FiroRpcTransaction {
+  hex: string;
+  txid: string;
+  hash: string;
+  size: number;
+  vsize: number;
+  version: number;
+  locktime: number;
+  vin: Array<FiroRpcTxInput>;
+  vout: Array<FiroRpcTxOutput>;
+  blockhash?: string;
+  confirmations?: number;
+  time?: number;
+  blocktime?: number;
+  instantlock?: boolean;
+  chainlock?: boolean;
+}

--- a/packages/rosen-extractor/lib/getRosenData/firo/utils.ts
+++ b/packages/rosen-extractor/lib/getRosenData/firo/utils.ts
@@ -1,0 +1,56 @@
+import { parseRosenData } from '../../utils';
+import { address } from 'bitcoinjs-lib';
+import { MinimalOnChainRosenData } from '../../types';
+
+const firoNetwork = {
+  // Firo network parameters
+  messagePrefix: '\x19Firo Signed Message:\n',
+  bech32: 'firo',
+  bip32: {
+    public: 0x0488b21e,
+    private: 0x0488ade4,
+  },
+  pubKeyHash: 0x52, // Firo mainnet uses 0x52 (a addresses), testnet uses 0x41 (T addresses)
+  scriptHash: 0x07,
+  wif: 0xd2,
+};
+
+/**
+ * Converts a Firocoin address to its corresponding output script
+ * @param addr The Firocoin address to convert
+ * @returns The output script as a hex string
+ */
+export const addressToOutputScript = (addr: string): string => {
+  try {
+    return address.toOutputScript(addr, firoNetwork).toString('hex');
+  } catch (e) {
+    throw new Error(
+      `Failed to convert Firo address to output script: ${e}. Only transparent addresses (P2PKH, P2SH) are supported. Privacy addresses (RAP, Spark, Lelantus) are not supported.`,
+    );
+  }
+};
+
+/**
+ * extracts rosen data from OP_RETURN box script pub key
+ * @param scriptPubKeyHex
+ */
+export const parseOpReturn = (
+  scriptPubKeyHex: string,
+): MinimalOnChainRosenData => {
+  // check OP_RETURN opcode
+  if (scriptPubKeyHex.slice(0, 2) !== '6a')
+    throw Error(`script does not start with OP_RETURN opcode (6a)`);
+
+  // check script length (should not use more than one OP_RETURN)
+  const dataLength = scriptPubKeyHex.slice(2, 4);
+  if (parseInt(dataLength, 16) + 2 !== scriptPubKeyHex.length / 2)
+    throw Error(
+      `script length is unexpected [${parseInt(dataLength, 16) + 3} !== ${
+        scriptPubKeyHex.length / 2
+      }]`,
+    );
+
+  const remainingData = scriptPubKeyHex.slice(4);
+
+  return parseRosenData(remainingData);
+};

--- a/packages/rosen-extractor/lib/index.ts
+++ b/packages/rosen-extractor/lib/index.ts
@@ -21,6 +21,8 @@ export { RosenData, TokenTransformation } from './getRosenData/abstract/types';
 export { DogeEsploraRosenExtractor } from './getRosenData/doge/dogeEsploraRosenExtractor';
 export { DogeRosenExtractor } from './getRosenData/doge/dogeRosenExtractor';
 export { DogeRpcRosenExtractor } from './getRosenData/doge/dogeRpcRosenExtractor';
+export { FiroRosenExtractor } from './getRosenData/firo/firoRosenExtractor';
+export { FiroRpcRosenExtractor } from './getRosenData/firo/firoRpcRosenExtractor';
 export { BitcoinRunesEsploraRosenExtractor } from './getRosenData/bitcoin-runes/bitcoinRunesEsploraRosenExtractor';
 export { BitcoinRunesRosenExtractor } from './getRosenData/bitcoin-runes/bitcoinRunesRosenExtractor';
 export { BitcoinRunesRpcRosenExtractor } from './getRosenData/bitcoin-runes/bitcoinRunesRpcRosenExtractor';

--- a/packages/rosen-extractor/tests/getRosenData/firo/firoRosenExtractor.spec.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/firoRosenExtractor.spec.ts
@@ -1,0 +1,184 @@
+import { FiroRosenExtractor } from '../../../lib';
+import * as testData from './testData';
+import TestUtils from '../testUtils';
+import { ERGO_CHAIN, ETHEREUM_CHAIN } from '../../../lib/getRosenData/const';
+import JsonBigInt from '@rosen-bridge/json-bigint';
+import { TokenMap } from '@rosen-bridge/tokens';
+
+describe('FiroRosenExtractor', () => {
+  const tokenMap = new TokenMap();
+
+  beforeAll(async () => {
+    await tokenMap.updateConfigByJson(TestUtils.tokens);
+  });
+
+  describe('get', () => {
+    /**
+     * @target `FiroRosenExtractor.get` should extract rosenData from
+     * FIRO locking tx successfully
+     * @dependencies
+     * @scenario
+     * - mock valid rosen data tx
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return expected rosenData object
+     */
+    it('should extract rosenData from FIRO locking tx successfully', () => {
+      const validLockTx = JsonBigInt.stringify(testData.txs.lockTx);
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.get(validLockTx);
+
+      expect(result).toStrictEqual(testData.rosenData);
+    });
+
+    /**
+     * @target `FiroRosenExtractor.get` should return undefined when
+     * there is only one output
+     * @dependencies
+     * @scenario
+     * - mock tx with only one output
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when there is only one output', () => {
+      const invalidTx = JsonBigInt.stringify(testData.txs.lessBoxes);
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRosenExtractor.get` should return undefined when
+     * first output is not OP_RETURN
+     * @dependencies
+     * @scenario
+     * - mock tx without OP_RETURN utxo
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when first output is not OP_RETURN', () => {
+      const invalidTx = JsonBigInt.stringify(testData.txs.noOpReturn);
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRosenExtractor.get` should return undefined when
+     * second output is not to lock address
+     * @dependencies
+     * @scenario
+     * - mock tx with no output box to lock address
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when second output is not to lock address', () => {
+      const invalidTx = JsonBigInt.stringify(testData.txs.noLock);
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRosenExtractor.get` should return undefined when
+     * no data is extracted from OP_RETURN box
+     * @dependencies
+     * @scenario
+     * - mock tx with invalid rosen data in OP_RETURN
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when no data is extracted from OP_RETURN box', () => {
+      const invalidTx = JsonBigInt.stringify(testData.txs.invalidData);
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRosenExtractor.get` should return undefined when
+     * token transformation is not possible
+     * @dependencies
+     * @scenario
+     * - mock valid lock tx
+     * - generate extractor with a tokenMap that does not support FIRO
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when token transformation is not possible', async () => {
+      const invalidTx = JsonBigInt.stringify(testData.txs.lockTx);
+
+      const noNativeTokenMap = new TokenMap();
+      await noNativeTokenMap.updateConfigByJson(TestUtils.noNativeTokens);
+      const extractor = new FiroRosenExtractor(
+        testData.lockAddress,
+        noNativeTokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAssetTransformation', () => {
+    /**
+     * @target `FiroRosenExtractor.getAssetTransformation` should return transformation
+     * successfully when FIRO is supported on target chain (Ergo)
+     * @dependencies
+     * @scenario
+     * - mock utxo
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return expected asset transformation
+     */
+    it('should return transformation successfully when FIRO is supported on target chain (Ergo)', () => {
+      const lockUtxo = testData.lockUtxo;
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.getAssetTransformation(lockUtxo, ERGO_CHAIN);
+
+      expect(result).toStrictEqual(testData.rsFiroErgoTransformation);
+    });
+
+    /**
+     * @target `FiroRosenExtractor.getAssetTransformation` should return undefined
+     * when FIRO is NOT supported on target chain (Ethereum)
+     * @dependencies
+     * @scenario
+     * - mock utxo
+     * - run test with unsupported target chain (Ethereum)
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when FIRO is NOT supported on target chain (Ethereum)', () => {
+      const lockUtxo = testData.lockUtxo;
+
+      const extractor = new FiroRosenExtractor(testData.lockAddress, tokenMap);
+      const result = extractor.getAssetTransformation(lockUtxo, ETHEREUM_CHAIN);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/rosen-extractor/tests/getRosenData/firo/firoRpcRosenExtractor.spec.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/firoRpcRosenExtractor.spec.ts
@@ -1,0 +1,205 @@
+import { FiroRpcRosenExtractor } from '../../../lib';
+import * as testData from './rpcTestData';
+import TestUtils from '../testUtils';
+import { ETHEREUM_CHAIN, ERGO_CHAIN } from '../../../lib/getRosenData/const';
+import { TokenMap } from '@rosen-bridge/tokens';
+import { FiroRpcTransaction } from '../../../lib/getRosenData/firo/types';
+
+describe('FiroRpcRosenExtractor', () => {
+  const tokenMap = new TokenMap();
+
+  beforeAll(async () => {
+    await tokenMap.updateConfigByJson(TestUtils.tokens);
+  });
+
+  describe('get', () => {
+    /**
+     * @target `FiroRpcRosenExtractor.get` should extract rosenData from
+     * FIRO locking tx successfully
+     * @dependencies
+     * @scenario
+     * - mock valid rosen data tx
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return expected rosenData object
+     */
+    it('should extract rosenData from FIRO locking tx successfully', () => {
+      const validLockTx = testData.txs.lockTx;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.get(validLockTx as FiroRpcTransaction);
+
+      expect(result).toStrictEqual(testData.rosenData);
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.get` should return undefined when
+     * there is only one output
+     * @dependencies
+     * @scenario
+     * - mock tx with only one output
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when there is only one output', () => {
+      const invalidTx = testData.txs.lessBoxes;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.get` should return undefined when
+     * no valid OP_RETURN output is found
+     * @dependencies
+     * @scenario
+     * - mock tx without OP_RETURN utxo
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when no valid OP_RETURN output is found', () => {
+      const invalidTx = testData.txs.noOpReturn;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.get` should return undefined when
+     * no output with the lock address is found
+     * @dependencies
+     * @scenario
+     * - mock tx with no output box to lock address
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when no output with the lock address is found', () => {
+      const invalidTx = testData.txs.noLock;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.get` should return undefined when
+     * no data is extracted from OP_RETURN box
+     * @dependencies
+     * @scenario
+     * - mock tx with invalid rosen data in OP_RETURN
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when no data is extracted from OP_RETURN box', () => {
+      const invalidTx = testData.txs.invalidData;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.get` should return undefined when
+     * token transformation is not possible
+     * @dependencies
+     * @scenario
+     * - mock valid lock tx
+     * - generate extractor with a tokenMap that does not support FIRO
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when token transformation is not possible', async () => {
+      const invalidTx = testData.txs.lockTx;
+
+      const noNativeTokenMap = new TokenMap();
+      await noNativeTokenMap.updateConfigByJson(TestUtils.noNativeTokens);
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        noNativeTokenMap,
+      );
+      const result = extractor.get(invalidTx);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAssetTransformation', () => {
+    /**
+     * @target `FiroRpcRosenExtractor.getAssetTransformation` should return transformation
+     * successfully when FIRO is supported on target chain (Ergo)
+     * @dependencies
+     * @scenario
+     * - mock utxo
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return expected asset transformation
+     */
+    it('should return transformation successfully when FIRO is supported on target chain (Ergo)', () => {
+      const lockUtxo = testData.lockUtxo;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.getAssetTransformation(lockUtxo, ERGO_CHAIN);
+
+      expect(result).toStrictEqual(testData.rsFiroErgoTransformation);
+    });
+
+    /**
+     * @target `FiroRpcRosenExtractor.getAssetTransformation` should return undefined
+     * when FIRO is NOT supported on target chain (Ethereum)
+     * @dependencies
+     * @scenario
+     * - mock utxo
+     * - run test with unsupported target chain (Ethereum)
+     * - check returned value
+     * @expected
+     * - it should return undefined
+     */
+    it('should return undefined when FIRO is NOT supported on target chain (Ethereum)', () => {
+      const lockUtxo = testData.lockUtxo;
+
+      const extractor = new FiroRpcRosenExtractor(
+        testData.lockAddress,
+        tokenMap,
+      );
+      const result = extractor.getAssetTransformation(lockUtxo, ETHEREUM_CHAIN);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/rosen-extractor/tests/getRosenData/firo/rpcTestData.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/rpcTestData.ts
@@ -1,0 +1,199 @@
+export const lockAddress = 'a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT';
+
+const baseTx = {
+  txid: 'b0d214c50032481f728dab5144cf37dd6232a71c4706246237f2a5c4ea56d1f5',
+  hash: 'b0d214c50032481f728dab5144cf37dd6232a71c4706246237f2a5c4ea56d1f5',
+  version: 1,
+  size: 200,
+  vsize: 200,
+  locktime: 0,
+  type: 0,
+  vin: [
+    {
+      txid: '835b8bfb12b7e9b9d3d946458e38c628a2df8ba8059ac9c664360836157b994e',
+      vout: 0,
+      scriptSig: {
+        asm: '30440220669a7ae8a5761abeda936725755ea1c661b83ff5bf3feff5dcd41d1abeabc96e022077df83be234e3667218a03d62e7bad9aeb3f1ec6e45f284db807373aa083a153[ALL] 03cfc2bd15d648c042642823ddb27a7dcbc2e2bf5a06194cb91c8d5ed7cbbc7632',
+        hex: '4730440220669a7ae8a5761abeda936725755ea1c661b83ff5bf3feff5dcd41d1abeabc96e022077df83be234e3667218a03d62e7bad9aeb3f1ec6e45f284db807373aa083a153012103cfc2bd15d648c042642823ddb27a7dcbc2e2bf5a06194cb91c8d5ed7cbbc7632',
+      },
+      sequence: 4294967295,
+    },
+  ],
+};
+
+export const txUtxos = {
+  lockTx: {
+    vout: [
+      {
+        value: 0,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_RETURN 00000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+          hex: '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+          type: 'nulldata',
+        },
+      },
+      {
+        value: 5.0,
+        n: 1,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 20f87f7f202c3d40dea06df136862fdbeef3f8e7 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+          type: 'pubkeyhash',
+          addresses: ['a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT'],
+        },
+      },
+      {
+        value: 15.0,
+        n: 2,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 369236a50667e799e9a1eb2d8f492ffec9d89e04 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a914369236a50667e799e9a1eb2d8f492ffec9d89e0488ac',
+          type: 'pubkeyhash',
+          addresses: ['a5h1PMR9eivcQ2XU8KMT3iLJ1m3rYRfAB2'],
+        },
+      },
+    ],
+  },
+  lessBoxes: {
+    vout: [
+      {
+        value: 20.0,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 20f87f7f202c3d40dea06df136862fdbeef3f8e7 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+          type: 'pubkeyhash',
+          addresses: ['a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT'],
+        },
+      },
+    ],
+  },
+  noOpReturn: {
+    vout: [
+      {
+        value: 5.0,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 20f87f7f202c3d40dea06df136862fdbeef3f8e7 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+          type: 'pubkeyhash',
+          addresses: ['a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT'],
+        },
+      },
+      {
+        value: 15.0,
+        n: 1,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 369236a50667e799e9a1eb2d8f492ffec9d89e04 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a914369236a50667e799e9a1eb2d8f492ffec9d89e0488ac',
+          type: 'pubkeyhash',
+          addresses: ['a5h1PMR9eivcQ2XU8KMT3iLJ1m3rYRfAB2'],
+        },
+      },
+    ],
+  },
+  noLock: {
+    vout: [
+      {
+        value: 0,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_RETURN 00000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+          hex: '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+          type: 'nulldata',
+        },
+      },
+      {
+        value: 20.0,
+        n: 1,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 369236a50667e799e9a1eb2d8f492ffec9d89e04 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a914369236a50667e799e9a1eb2d8f492ffec9d89e0488ac',
+          type: 'pubkeyhash',
+          addresses: ['a5h1PMR9eivcQ2XU8KMT3iLJ1m3rYRfAB2'],
+        },
+      },
+    ],
+  },
+  invalidData: {
+    vout: [
+      {
+        value: 0,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_RETURN 090000000000989680000000000098968039018dd8d9339deaf201790f6891adebb3abd78c90f3231aa95f12ce8f9ab18016dab2d790baeecb323f792babc1a769511b4a3262e6703f24c1',
+          hex: '6a4b090000000000989680000000000098968039018dd8d9339deaf201790f6891adebb3abd78c90f3231aa95f12ce8f9ab18016dab2d790baeecb323f792babc1a769511b4a3262e6703f24c1',
+          type: 'nulldata',
+        },
+      },
+      {
+        value: 20.0,
+        n: 1,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 20f87f7f202c3d40dea06df136862fdbeef3f8e7 OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+          type: 'pubkeyhash',
+          addresses: ['a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT'],
+        },
+      },
+    ],
+  },
+};
+
+export const txs = {
+  lockTx: {
+    ...baseTx,
+    ...txUtxos.lockTx,
+  },
+  lessBoxes: {
+    ...baseTx,
+    ...txUtxos.lessBoxes,
+  },
+  noOpReturn: {
+    ...baseTx,
+    ...txUtxos.noOpReturn,
+  },
+  noLock: {
+    ...baseTx,
+    ...txUtxos.noLock,
+  },
+  invalidData: {
+    ...baseTx,
+    ...txUtxos.invalidData,
+  },
+};
+
+export const rosenData = {
+  toChain: 'ergo',
+  toAddress: '9iMjQx8PzwBKXRvsFUJFJAPoy31znfEeBUGz8DRkcnJX4rJYjVd',
+  bridgeFee: '10000000',
+  networkFee: '10000000',
+  fromAddress:
+    'box:835b8bfb12b7e9b9d3d946458e38c628a2df8ba8059ac9c664360836157b994e.0',
+  sourceChainTokenId: 'firo',
+  amount: '500000000',
+  targetChainTokenId:
+    'e15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+  sourceTxId:
+    'b0d214c50032481f728dab5144cf37dd6232a71c4706246237f2a5c4ea56d1f5',
+  rawData:
+    '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+};
+
+export const lockUtxo = {
+  n: 1,
+  scriptPubKey: {
+    asm: 'OP_DUP OP_HASH160 20f87f7f202c3d40dea06df136862fdbeef3f8e7 OP_EQUALVERIFY OP_CHECKSIG',
+    hex: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+    address: 'a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT',
+    type: 'pubkeyhash',
+  },
+  value: 5.0,
+};
+
+export const rsFiroErgoTransformation = {
+  from: 'firo',
+  to: 'e15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+  amount: '500000000',
+};

--- a/packages/rosen-extractor/tests/getRosenData/firo/testData.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/testData.ts
@@ -1,0 +1,141 @@
+export const lockAddress = 'a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT';
+
+export const baseTx = {
+  id: '835b8bfb12b7e9b9d3d946458e38c628a2df8ba8059ac9c664360836157b994e',
+  inputs: [
+    {
+      txId: '7f1a2e3d4c5b6a9e8f7d6c5b4a3e2d1c9b8a7f6e5d4c3b2a1f0e9d8c7b6a5f4',
+      index: 0,
+      scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+    },
+  ],
+};
+
+export const txUtxos = {
+  lockTx: {
+    outputs: [
+      {
+        scriptPubKey:
+          '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+        value: 0n,
+      },
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 10000000n,
+      },
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 15584394312n,
+      },
+    ],
+  },
+  lessBoxes: {
+    outputs: [
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 15594394312n,
+      },
+    ],
+  },
+  noOpReturn: {
+    outputs: [
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 10000000n,
+      },
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 15584394312n,
+      },
+    ],
+  },
+  noLock: {
+    outputs: [
+      {
+        scriptPubKey:
+          '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+        value: 0n,
+      },
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ab',
+        value: 15594394312n,
+      },
+    ],
+  },
+  invalidData: {
+    outputs: [
+      {
+        scriptPubKey:
+          '6a3309000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+        value: 0n,
+      },
+      {
+        scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+        value: 15594394312n,
+      },
+    ],
+  },
+};
+
+export const txs = {
+  lockTx: {
+    ...baseTx,
+    ...txUtxos.lockTx,
+  },
+  lessBoxes: {
+    ...baseTx,
+    ...txUtxos.lessBoxes,
+  },
+  noOpReturn: {
+    ...baseTx,
+    ...txUtxos.noOpReturn,
+  },
+  noLock: {
+    ...baseTx,
+    ...txUtxos.noLock,
+  },
+  invalidData: {
+    ...baseTx,
+    ...txUtxos.invalidData,
+  },
+};
+
+export const rosenData = {
+  toChain: 'ergo',
+  toAddress: '9iMjQx8PzwBKXRvsFUJFJAPoy31znfEeBUGz8DRkcnJX4rJYjVd',
+  bridgeFee: '10000000',
+  networkFee: '10000000',
+  fromAddress:
+    'box:7f1a2e3d4c5b6a9e8f7d6c5b4a3e2d1c9b8a7f6e5d4c3b2a1f0e9d8c7b6a5f4.0',
+  sourceChainTokenId: 'firo',
+  amount: '10000000',
+  targetChainTokenId:
+    'e15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+  sourceTxId:
+    '835b8bfb12b7e9b9d3d946458e38c628a2df8ba8059ac9c664360836157b994e',
+  rawData:
+    '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+};
+
+export const lockUtxo = {
+  scriptPubKey: '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac',
+  value: 10000000n,
+};
+
+export const rsFiroCardanoTransformation = {
+  from: 'firo',
+  to: 'c15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+  amount: '10000000',
+};
+
+export const rsFiroErgoTransformation = {
+  from: 'firo',
+  to: 'e15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+  amount: '10000000',
+};
+
+export const rsFiroBitcoinTransformation = {
+  amount: '10000000',
+  from: 'firo',
+  to: 'b8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8.6669726f',
+};

--- a/packages/rosen-extractor/tests/getRosenData/firo/utils.spec.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/utils.spec.ts
@@ -1,0 +1,96 @@
+import {
+  parseOpReturn,
+  addressToOutputScript,
+} from '../../../lib/getRosenData/firo/utils';
+import * as testData from './utilsTestData';
+
+describe('parseOpReturn', () => {
+  /**
+   * @target parseOpReturn should extract rosen data successfully
+   * @dependencies
+   * @scenario
+   * - mock utxo with scriptPubKey that contains valid rosen data
+   * - run test
+   * - check returned value
+   * @expected
+   * - it should return expected asset transformation
+   */
+  it('should extract rosen data successfully', () => {
+    const script = testData.opReturnScripts.valid;
+    const result = parseOpReturn(script);
+
+    expect(result).toStrictEqual(testData.opReturnData);
+  });
+
+  /**
+   * @target parseOpReturn should throw error
+   * when script does not start with OP_RETURN opcode
+   * @dependencies
+   * @scenario
+   * - mock utxo with scriptPubKey that does not contain OP_RETURN opcode
+   * - run test & check thrown exception
+   * @expected
+   * - it should throw error
+   */
+  it('should throw error when script does not start with OP_RETURN opcode', () => {
+    const script = testData.opReturnScripts.noOpReturn;
+
+    expect(() => {
+      parseOpReturn(script);
+    }).toThrow('script does not start with OP_RETURN opcode (6a)');
+  });
+
+  /**
+   * @target parseOpReturn should throw error
+   * when toChain is invalid
+   * @dependencies
+   * @scenario
+   * - mock utxo with scriptPubKey that contain rosen data with invalid toChain
+   * - run test & check thrown exception
+   * @expected
+   * - it should throw error
+   */
+  it('should throw error when toChain is invalid', () => {
+    const script = testData.opReturnScripts.invalidToChain;
+
+    expect(() => {
+      parseOpReturn(script);
+    }).toThrow(/invalid toChain code/);
+  });
+});
+
+describe('addressToOutputScript', () => {
+  /**
+   * @target addressToOutputScript should convert a Firocoin address to its corresponding output script
+   * @dependencies
+   * @scenario
+   * - provide a valid Firocoin address
+   * - run test
+   * - check returned value
+   * @expected
+   * - it should return the correct output script
+   */
+  it('should convert a Firocoin address to its corresponding output script', () => {
+    const address = testData.validFiroAddress;
+    const result = addressToOutputScript(address);
+
+    expect(result).toBe(testData.validFiroOutputScript);
+  });
+
+  /**
+   * @target addressToOutputScript should throw an error for an invalid Firocoin address
+   * @dependencies
+   * @scenario
+   * - provide an invalid Firocoin address
+   * - run test & check thrown exception
+   * @expected
+   * - it should throw an error
+   */
+  it('should throw an error for an invalid Firocoin address', () => {
+    const invalidAddress = testData.invalidFiroAddress;
+
+    expect(() => {
+      addressToOutputScript(invalidAddress);
+    }).toThrow();
+  });
+});

--- a/packages/rosen-extractor/tests/getRosenData/firo/utilsTestData.ts
+++ b/packages/rosen-extractor/tests/getRosenData/firo/utilsTestData.ts
@@ -1,0 +1,19 @@
+export const validFiroAddress = 'a3io3zMLfg9nchA3KSoSEvPz1tztnKDuaT';
+export const validFiroOutputScript =
+  '76a91420f87f7f202c3d40dea06df136862fdbeef3f8e788ac';
+export const invalidFiroAddress = 'a3io3zMLfg9nchA3KSoSEvPz1tztnKDUZZ';
+export const opReturnScripts = {
+  valid:
+    '6a3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+  noOpReturn:
+    '3300000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+  invalidToChain:
+    '6a3309000000000098968000000000009896802103f999da8e6e42660e4464d17d29e63bc006734a6710a24eb489b466323d3a9339',
+};
+
+export const opReturnData = {
+  toChain: 'ergo',
+  toAddress: '9iMjQx8PzwBKXRvsFUJFJAPoy31znfEeBUGz8DRkcnJX4rJYjVd',
+  bridgeFee: '10000000',
+  networkFee: '10000000',
+};

--- a/packages/rosen-extractor/tests/getRosenData/testUtils.ts
+++ b/packages/rosen-extractor/tests/getRosenData/testUtils.ts
@@ -12,6 +12,8 @@ import {
   ERGO_NATIVE_TOKEN,
   DOGE_CHAIN,
   DOGE_NATIVE_TOKEN,
+  FIRO_CHAIN,
+  FIRO_NATIVE_TOKEN,
 } from '../../lib/getRosenData/const';
 
 export default class TestUtils {
@@ -150,6 +152,24 @@ export default class TestUtils {
         tokenId:
           'dcbda15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f48',
         name: 'rsDOGE',
+        decimals: 8,
+        type: 'EIP-004',
+        residency: 'wrapped',
+        extra: {},
+      },
+    },
+    {
+      [FIRO_CHAIN]: {
+        tokenId: FIRO_NATIVE_TOKEN,
+        name: FIRO_NATIVE_TOKEN,
+        decimals: 8,
+        type: 'tokenType',
+        residency: 'tokenResidency',
+        extra: {},
+      },
+      [ERGO_CHAIN]: {
+        tokenId: 'e15f1361f5eeba416dd63e059fce34f0c57499e9afe733ea0fd59cf63f49',
+        name: 'rsFIRO',
         decimals: 8,
         type: 'EIP-004',
         residency: 'wrapped',


### PR DESCRIPTION
This PR integrates the Firo blockchain into the `address-codec` package by defining specific network constants and updating the encoder, decoder, and validator modules. These changes enable the system to correctly handle Firo addresses—supporting both P2PKH and P2SH formats—using standard Bitcoin library primitives similar to existing chain implementations.

The update also extends the `rosen-extractor` package by introducing `FiroRosenExtractor` and `FiroRpcRosenExtractor` classes. These components are designed to parse lock transactions from serialized JSON or direct RPC responses, specifically looking for `OP_RETURN` metadata to identify bridge requests and validating that assets are correctly sent to the lock address.

To support these features, the PR includes new utility functions for generating Firo output scripts and parsing bridge data. The implementation is verified through comprehensive unit tests for address manipulation and transaction parsing, along with a production integration test suite for validating interactions with a Firo RPC node.