### PR TITLE
feat: add Base support to address codec and rosen extractor

### DIFF
--- a/.changeset/base-utils-registration.md
+++ b/.changeset/base-utils-registration.md
@@ -1,0 +1,6 @@
+---
+'@rosen-bridge/address-codec': minor
+'@rosen-bridge/rosen-extractor': minor
+---
+
+Register Base as a supported EVM chain in address-codec and rosen-extractor.

--- a/packages/address-codec/lib/const.ts
+++ b/packages/address-codec/lib/const.ts
@@ -1,2 +1,3 @@
+export const BASE_CHAIN = 'base';
 export const ETHEREUM_CHAIN = 'ethereum';
 export const BINANCE_CHAIN = 'binance';

--- a/packages/address-codec/lib/decoder.ts
+++ b/packages/address-codec/lib/decoder.ts
@@ -28,13 +28,14 @@ import {
   decodeHandshakeAddress,
 } from '@rosen-bridge/address-codec-handshake';
 
-import { BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
+import { BASE_CHAIN, BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
 import { UnsupportedChainError } from './types';
 
 export const chainDecoders: Record<string, (address: string) => string> = {
   [ERGO_CHAIN]: decodeErgoAddress,
   [CARDANO_CHAIN]: decodeCardanoAddress,
   [BITCOIN_CHAIN]: decodeBitcoinAddress,
+  [BASE_CHAIN]: generateEvmAddressDecoder(BASE_CHAIN),
   [ETHEREUM_CHAIN]: generateEvmAddressDecoder(ETHEREUM_CHAIN),
   [BINANCE_CHAIN]: generateEvmAddressDecoder(BINANCE_CHAIN),
   [DOGE_CHAIN]: decodeDogeAddress,

--- a/packages/address-codec/lib/encoder.ts
+++ b/packages/address-codec/lib/encoder.ts
@@ -28,13 +28,14 @@ import {
   encodeHandshakeAddress,
 } from '@rosen-bridge/address-codec-handshake';
 
-import { BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
+import { BASE_CHAIN, BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
 import { UnsupportedChainError } from './types';
 
 export const chainEncoders: Record<string, (address: string) => string> = {
   [ERGO_CHAIN]: encodeErgoAddress,
   [CARDANO_CHAIN]: encodeCardanoAddress,
   [BITCOIN_CHAIN]: encodeBitcoinAddress,
+  [BASE_CHAIN]: generateEvmAddressEncoder(BASE_CHAIN),
   [ETHEREUM_CHAIN]: generateEvmAddressEncoder(ETHEREUM_CHAIN),
   [BINANCE_CHAIN]: generateEvmAddressEncoder(BINANCE_CHAIN),
   [DOGE_CHAIN]: encodeDogeAddress,

--- a/packages/address-codec/lib/validator.ts
+++ b/packages/address-codec/lib/validator.ts
@@ -28,13 +28,14 @@ import {
   validateHandshakeAddress,
 } from '@rosen-bridge/address-codec-handshake';
 
-import { BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
+import { BASE_CHAIN, BINANCE_CHAIN, ETHEREUM_CHAIN } from './const';
 import { UnsupportedChainError } from './types';
 
 export const chainValidators: Record<string, (address: string) => void> = {
   [ERGO_CHAIN]: validateErgoAddress,
   [CARDANO_CHAIN]: validateCardanoAddress,
   [BITCOIN_CHAIN]: validateBitcoinAddress,
+  [BASE_CHAIN]: generateEvmAddressValidator(BASE_CHAIN),
   [ETHEREUM_CHAIN]: generateEvmAddressValidator(ETHEREUM_CHAIN),
   [BINANCE_CHAIN]: generateEvmAddressValidator(BINANCE_CHAIN),
   [DOGE_CHAIN]: validateDogeAddress,

--- a/packages/address-codec/tests/decoder.spec.ts
+++ b/packages/address-codec/tests/decoder.spec.ts
@@ -1,4 +1,5 @@
 import { UnsupportedChainError, decodeAddress } from '../lib';
+import { BASE_CHAIN } from '../lib/const';
 
 describe('decodeAddress', () => {
   /**
@@ -13,5 +14,11 @@ describe('decodeAddress', () => {
     expect(() => {
       decodeAddress('unsupported-chain', '0011223344');
     }).toThrow(UnsupportedChainError);
+  });
+
+  it('should decode base addresses using the shared EVM decoder', () => {
+    expect(
+      decodeAddress(BASE_CHAIN, '4200000000000000000000000000000000000006'),
+    ).toBe('0x4200000000000000000000000000000000000006');
   });
 });

--- a/packages/address-codec/tests/encoder.spec.ts
+++ b/packages/address-codec/tests/encoder.spec.ts
@@ -1,4 +1,5 @@
 import { UnsupportedChainError, encodeAddress } from '../lib';
+import { BASE_CHAIN } from '../lib/const';
 
 describe('encodeAddress', () => {
   /**
@@ -13,5 +14,11 @@ describe('encodeAddress', () => {
     expect(() => {
       encodeAddress('unsupported-chain', 'address');
     }).toThrow(UnsupportedChainError);
+  });
+
+  it('should encode base addresses using the shared EVM encoder', () => {
+    expect(
+      encodeAddress(BASE_CHAIN, '0x4200000000000000000000000000000000000006'),
+    ).toBe('4200000000000000000000000000000000000006');
   });
 });

--- a/packages/address-codec/tests/validator.spec.ts
+++ b/packages/address-codec/tests/validator.spec.ts
@@ -1,4 +1,5 @@
 import { UnsupportedChainError, validateAddress } from '../lib';
+import { BASE_CHAIN } from '../lib/const';
 
 describe('validateAddress', () => {
   /**
@@ -13,5 +14,11 @@ describe('validateAddress', () => {
     expect(() => {
       validateAddress('unsupported-chain', '0011223344');
     }).toThrow(UnsupportedChainError);
+  });
+
+  it('should validate base addresses using the shared EVM validator', () => {
+    expect(() => {
+      validateAddress(BASE_CHAIN, '0x4200000000000000000000000000000000000006');
+    }).not.toThrow();
   });
 });

--- a/packages/rosen-extractor/lib/getRosenData/const.ts
+++ b/packages/rosen-extractor/lib/getRosenData/const.ts
@@ -2,6 +2,7 @@ export const CARDANO_NATIVE_TOKEN = 'ada';
 export const ERGO_NATIVE_TOKEN = 'erg';
 export const BITCOIN_NATIVE_TOKEN = 'btc';
 export const BITCOIN_CHAIN = 'bitcoin';
+export const BASE_CHAIN = 'base';
 export const ETHEREUM_CHAIN = 'ethereum';
 export const BINANCE_CHAIN = 'binance';
 export const CARDANO_CHAIN = 'cardano';
@@ -23,4 +24,5 @@ export const SUPPORTED_CHAINS = [
   BITCOIN_RUNES_CHAIN,
   FIRO_CHAIN,
   HANDSHAKE_CHAIN,
+  BASE_CHAIN,
 ];


### PR DESCRIPTION
## Summary

Add Base registrations to the shared utility packages required for Rosen chain integration.

This PR closes the missing `utils` pieces called out during review by registering Base in both `rosen-extractor` and `address-codec` using the shared EVM path.

## Changes

- add `BASE_CHAIN` to `address-codec` constants
- register Base in the shared EVM encoder, decoder, and validator maps
- add Base address codec tests for encode, decode, and validate flows
- add Base to `rosen-extractor` supported chains
- add a changeset for `address-codec` and `rosen-extractor`
