### PR TITLE
Fix extended-typeorm ESM imports

### DIFF
--- a/.changeset/fix-extended-typeorm-esm-imports.md
+++ b/.changeset/fix-extended-typeorm-esm-imports.md
@@ -1,0 +1,5 @@
+---
+'@rosen-bridge/extended-typeorm': patch
+---
+
+Fix ESM import specifiers so the package loads correctly under Node 22.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,7 +54,7 @@ npx @rosen-bridge/cli download-assets --chain-type mainnet --out rosen
 docker solution:
 
 ```shell
-docker run -it --rm -v "$PWD"/rosen:/usr/src/app/rosen -w /usr/src/app node:20.11 npx --yes @rosen-bridge/cli download-assets --chain-type mainnet --out rosen
+docker run -it --rm -v "$PWD"/rosen:/usr/src/app/rosen -w /usr/src/app node:22.18.0 npx --yes @rosen-bridge/cli download-assets --chain-type mainnet --out rosen
 ```
 
 Download assets for testnet into a `rosen` directory. If some pre-releases are
@@ -77,7 +77,7 @@ npx @rosen-bridge/cli tss-secret -t eddsa generate
 docker solution for `ecdsa`:
 
 ```shell
-docker run -it --rm node:20.11 npx --yes @rosen-bridge/cli tss-secret -t ecdsa generate
+docker run -it --rm node:22.18.0 npx --yes @rosen-bridge/cli tss-secret -t ecdsa generate
 ```
 
 Convert secret to pk:
@@ -90,7 +90,7 @@ npx @rosen-bridge/cli tss-secret -t eddsa convert-to-pk YOUR_TSS_SECRET
 docker solution for `ecdsa`:
 
 ```shell
-docker run -it --rm node:20.11 npx --yes @rosen-bridge/cli tss-secret -t ecdsa convert-to-pk YOUR_TSS_SECRET
+docker run -it --rm node:22.18.0 npx --yes @rosen-bridge/cli tss-secret -t ecdsa convert-to-pk YOUR_TSS_SECRET
 ```
 
 ### `blake2b-hash`
@@ -112,5 +112,5 @@ npx @rosen-bridge/cli blake2b-hash hello
 docker solution:
 
 ```shell
-docker run -it --rm node:20.11 npx --yes @rosen-bridge/cli blake2b-hash hello
+docker run -it --rm node:22.18.0 npx --yes @rosen-bridge/cli blake2b-hash hello
 ```

--- a/packages/extended-typeorm/lib/customQueryRunner.ts
+++ b/packages/extended-typeorm/lib/customQueryRunner.ts
@@ -1,7 +1,7 @@
 import { Mutex, MutexInterface } from 'async-mutex';
-import { SqliteDriver } from 'typeorm/driver/sqlite/SqliteDriver';
-import { SqliteQueryRunner } from 'typeorm/driver/sqlite/SqliteQueryRunner';
-import { IsolationLevel } from 'typeorm/driver/types/IsolationLevel';
+import { SqliteDriver } from 'typeorm/driver/sqlite/SqliteDriver.js';
+import { SqliteQueryRunner } from 'typeorm/driver/sqlite/SqliteQueryRunner.js';
+import { IsolationLevel } from 'typeorm/driver/types/IsolationLevel.js';
 
 class CustomQueryRunner extends SqliteQueryRunner {
   releaseMutex: MutexInterface.Releaser | null;

--- a/packages/extended-typeorm/lib/dataSource.ts
+++ b/packages/extended-typeorm/lib/dataSource.ts
@@ -1,6 +1,6 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
 
-import { SqliteDriver } from './sqliteDriver';
+import { SqliteDriver } from './sqliteDriver.js';
 
 class CustomDataSource extends DataSource {
   constructor(options: DataSourceOptions) {

--- a/packages/extended-typeorm/lib/index.ts
+++ b/packages/extended-typeorm/lib/index.ts
@@ -1,3 +1,3 @@
 export * from 'typeorm';
-export { DataSource } from './dataSource';
-export { BigIntValueTransformer } from './bigIntTransformer';
+export { DataSource } from './dataSource.js';
+export { BigIntValueTransformer } from './bigIntTransformer.js';

--- a/packages/extended-typeorm/lib/sqliteDriver.ts
+++ b/packages/extended-typeorm/lib/sqliteDriver.ts
@@ -1,8 +1,8 @@
 import { Mutex } from 'async-mutex';
 import { DataSource, QueryRunner, ReplicationMode } from 'typeorm';
-import { SqliteDriver } from 'typeorm/driver/sqlite/SqliteDriver';
+import { SqliteDriver } from 'typeorm/driver/sqlite/SqliteDriver.js';
 
-import { CustomQueryRunner } from './customQueryRunner';
+import { CustomQueryRunner } from './customQueryRunner.js';
 
 class CustomSqliteDriver extends SqliteDriver {
   protected mutex: Mutex;


### PR DESCRIPTION
## Why

- Make @rosen-bridge/extended-typeorm load correctly under native Node 22 ESM resolution.
- Keep CLI Docker examples aligned with the Rosen Node 22 baseline.

## Changes

- Add .js specifiers to relative runtime imports in extended-typeorm TypeScript source.
- Add a changeset for the ESM import fix.
- Update CLI README Docker examples from Node 20.11 to Node 22.18.0.

## Dependency Notes

This package-level ESM fix is independent from the notification package fix, but both should be published before the watcher Node 22 release.

Related prerequisite package fix:

- https://github.com/rosen-bridge/notification/pull/1

## Checks

- npm run type-check --workspace @rosen-bridge/extended-typeorm
- npm run build --workspace @rosen-bridge/extended-typeorm
- npm run test --workspace @rosen-bridge/extended-typeorm: 2 passed
- npm run type-check --workspace @rosen-bridge/cli
- npm run test --workspaces --if-present